### PR TITLE
Fixed missing end parentheses

### DIFF
--- a/src/ExceptionMessageBeautifier.js
+++ b/src/ExceptionMessageBeautifier.js
@@ -12,7 +12,7 @@ var formatException = function(exceptionMessage){
             repl: '\r\n ---> '},
         {
             find:/\) at /g,
-            repl: '\r\n at '},
+            repl: '\r\n\) at '},
         {
             find:/ --- End of inner exception stack trace ---/g, 
             repl: '\r\n   --- End of inner exception stack trace ---'}            

--- a/src/ExceptionMessageBeautifier.js
+++ b/src/ExceptionMessageBeautifier.js
@@ -12,7 +12,7 @@ var formatException = function(exceptionMessage){
             repl: '\r\n ---> '},
         {
             find:/\) at /g,
-            repl: '\r\n\) at '},
+            repl: ')\r\n at '},
         {
             find:/ --- End of inner exception stack trace ---/g, 
             repl: '\r\n   --- End of inner exception stack trace ---'}            


### PR DESCRIPTION
Added missing `)` to the `) at ` replacement.

I don't think I need to escape the `)` in the string. But I don't have a way to test this.